### PR TITLE
fix link to PixiJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://benchmarks.slaylines.io/
 
 ## Description
 
-- [PixiJS](https://pixijs.com) vs [Two.js](https://two.js.org/) vs [Paper.js](http://paperjs.org/);
+- [PixiJS](https://www.pixijs.com) vs [Two.js](https://two.js.org/) vs [Paper.js](http://paperjs.org/);
 - 1000, 2000 or 5000 different rectangles moving on canvas with different speed.
 
 ## Quick Start


### PR DESCRIPTION
Without the "www" I get an SSL error in Firefox and Chrome on Linux.