### PR TITLE
Make pixi.js comparison fair

### DIFF
--- a/src/scripts/pixi.js
+++ b/src/scripts/pixi.js
@@ -26,7 +26,7 @@ class PixiEngine extends Engine {
     }
 
     rectsToRemove.forEach(i => {
-      this.rects[i].x = this.width + this.rects[i].size;
+      this.rects[i].x = this.width + this.rects[i].size / 2;
     });
 
     this.meter.tick();

--- a/src/scripts/pixi.js
+++ b/src/scripts/pixi.js
@@ -12,34 +12,21 @@ class PixiEngine extends Engine {
       backgroundColor: 0xFFFFFF,
       antialias: true,
     });
-    this.app.stage.interactive = true;
-    this.graphics = new PIXI.Graphics();
-    this.app.stage.addChild(this.graphics);
-
     this.content.appendChild(this.app.view);
   }
 
-  renderRect(x, y, size) {
-    this.graphics.lineStyle(1, 0x000000, 1);
-    this.graphics.beginFill(0xFFFFFF);
-    this.graphics.drawRect(x - size / 2, y - size / 2, size, size);
-    this.graphics.endFill();
-  }
-
   onTick() {
-    this.graphics.clear();
-
     const rectsToRemove = [];
 
     for (let i = 0; i < this.count.value; i++) {
       const rect = this.rects[i];
       rect.x -= rect.speed;
-      this.renderRect(rect.x, rect.y, rect.size);
+      rect.el.position.x = rect.x - rect.size / 2;
       if (rect.x + rect.size / 2 < 0) rectsToRemove.push(i);
     }
 
     rectsToRemove.forEach(i => {
-      this.rects[i].x = this.width + this.rects[i].size / 2;
+      this.rects[i].x = this.width + this.rects[i].size;
     });
 
     this.meter.tick();
@@ -47,17 +34,22 @@ class PixiEngine extends Engine {
 
   render() {
     this.app.ticker.remove(this.onTick, this);
-    this.graphics.clear();
-
+    this.app.stage.removeChildren();
     this.rects = {};
     for (let i = 0; i < this.count.value; i++) {
-      const x = Math.random() * this.width;
-      const y = Math.random() * this.height;
       const size = 10 + Math.random() * 40;
+      const x = Math.random() * this.width - size / 2;
+      const y = Math.random() * this.height - size / 2;
       const speed = 1 + Math.random();
 
-      this.renderRect(x, y, size);
-      this.rects[i] = { x, y, size, speed };
+      const rect = new PIXI.Graphics();
+      rect.lineStyle(1, 0x000000, 1);
+      rect.beginFill(0xffffff);
+      rect.drawRect(0, 0, size, size);
+      rect.endFill();
+      rect.position.set(x, y);
+      this.app.stage.addChild(rect);
+      this.rects[i] = { x, y, size, speed, el: rect };
     }
 
     this.app.ticker.add(this.onTick, this);

--- a/src/scripts/pixi.js
+++ b/src/scripts/pixi.js
@@ -37,9 +37,9 @@ class PixiEngine extends Engine {
     this.app.stage.removeChildren();
     this.rects = {};
     for (let i = 0; i < this.count.value; i++) {
+      const x = Math.random() * this.width;
+      const y = Math.random() * this.height;
       const size = 10 + Math.random() * 40;
-      const x = Math.random() * this.width - size / 2;
-      const y = Math.random() * this.height - size / 2;
       const speed = 1 + Math.random();
 
       const rect = new PIXI.Graphics();
@@ -47,7 +47,7 @@ class PixiEngine extends Engine {
       rect.beginFill(0xffffff);
       rect.drawRect(0, 0, size, size);
       rect.endFill();
-      rect.position.set(x, y);
+      rect.position.set(x - size / 2, y - size / 2);
       this.app.stage.addChild(rect);
       this.rects[i] = { x, y, size, speed, el: rect };
     }

--- a/src/scripts/pixi.js
+++ b/src/scripts/pixi.js
@@ -21,7 +21,7 @@ class PixiEngine extends Engine {
     for (let i = 0; i < this.count.value; i++) {
       const rect = this.rects[i];
       rect.x -= rect.speed;
-      rect.el.position.x = rect.x - rect.size / 2;
+      rect.el.position.x = rect.x;
       if (rect.x + rect.size / 2 < 0) rectsToRemove.push(i);
     }
 
@@ -45,9 +45,9 @@ class PixiEngine extends Engine {
       const rect = new PIXI.Graphics();
       rect.lineStyle(1, 0x000000, 1);
       rect.beginFill(0xffffff);
-      rect.drawRect(0, 0, size, size);
+      rect.drawRect(-size / 2, -size / 2, size, size);
       rect.endFill();
-      rect.position.set(x - size / 2, y - size / 2);
+      rect.position.set(x, y);
       this.app.stage.addChild(rect);
       this.rects[i] = { x, y, size, speed, el: rect };
     }


### PR DESCRIPTION
The comparison is currently unfair, in both the Two.js and Paper.js cases the rectangles are created then their position is updated each frame.

In the Pixi.js the rectangles are created from scratch every frame which means they need to be retesselated every frame.

This makes the Pixi.js code match the other two in structure and as a result makes it much quicker.