### PR TITLE
Improve THREE.js implementation

### DIFF
--- a/src/scripts/three.js
+++ b/src/scripts/three.js
@@ -1,8 +1,5 @@
 import Engine from "./engine";
 import * as THREE from "three";
-import {LineMaterial} from "three/examples/jsm/lines/LineMaterial"
-import { Line2 } from 'three/examples/jsm/lines/Line2.js';
-import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 
 class ThreeEngine extends Engine {
   constructor() {
@@ -14,87 +11,59 @@ class ThreeEngine extends Engine {
       1000
     );
     this.camera.position.set(this.width / 2, this.height / 2, 500);
-    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer = new THREE.WebGLRenderer({ antialias: true , depth: false});
     this.renderer.setPixelRatio( window.devicePixelRatio );
     this.renderer.setSize(this.width, this.height);
+    this.renderer.sortObjects = false; // Allows squares to be drawn on top of each other
     this.content.appendChild(this.renderer.domElement);
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color("white");
   }
 
-  makeRect(x, y, size) {
-    const rect = new THREE.Shape();
-    const points = [];
-    points.push(new THREE.Vector3(- size / 2, - size / 2, 0));
-    points.push(new THREE.Vector3( size / 2, - size / 2, 0));
-    points.push(new THREE.Vector3(size / 2, size / 2, 0));
-    points.push(new THREE.Vector3(- size / 2, size / 2, 0));
-    points.push(new THREE.Vector3(- size / 2, - size / 2, 0));
-    rect.moveTo(points[0].x, points[0].y);
-    points.forEach((p) => {
-      rect.lineTo(p.x, p.y);
-    });
-    const linePos = []
-    points.forEach((p) => {
-        linePos.push(p.x,p.y,p.z)
-      });
+  makeRect(x, y, size, speed) {
+    const geometry = new THREE.PlaneGeometry( size, size );
+    const material = new THREE.MeshBasicMaterial( {color: 0xffffff, side: THREE.FrontSide, depthTest: false} );
+    const plane = new THREE.Mesh( geometry, material );
+    plane.position.set(x, y, 0);
+    plane.userData["speed"] = speed;
+    this.scene.add( plane );
 
-    const geometry = new THREE.ShapeGeometry(rect);
-    const fillMat = new THREE.MeshBasicMaterial({
-      color: new THREE.Color().setStyle("white"),
-      side: THREE.DoubleSide,
-      depthWrite: false,
-    });
-    const mesh = new THREE.Mesh(geometry, fillMat);
-
-    const strokeMaterial = new LineMaterial({
-      color:  new THREE.Color().setStyle("black"),
-      linewidth: 0.002,
-    });
-    const lineGeometry = new LineGeometry().setPositions(linePos);
-    const line = new Line2(lineGeometry, strokeMaterial);
-
-    const rectThree = new THREE.Group();
-    rectThree.add(mesh, line);
-    rectThree.position.x = x
-    rectThree.position.y = y
-
-    return rectThree;
+    // Make the borders of the planes
+    const edges = new THREE.EdgesGeometry( geometry );
+    const line = new THREE.LineSegments( edges, new THREE.LineBasicMaterial( { color: 0x000000 } ) );
+    line.position.set(x, y, 0);
+    line.userData["speed"] = speed;
+    this.scene.add( line );
   }
 
   animate() {
-    const rectsToRemove = [];
-    for (let i = 0; i < this.count.value; i++) {
-      const r = this.rects[i];
-      r.el.position.x -= r.speed;
-
-      if ( r.el.position.x + r.size / 2 < 0) rectsToRemove.push(i);
+    let size;
+    for(let child of this.scene.children) {
+      child.position.x -= child.userData.speed;
+      if(child.type === "Mesh") { // borders come directly after planes in the scene
+        size = child.geometry.parameters.width;
+      }
+      if (child.position.x + size * 2 < 0) {
+        child.position.x = this.width + size * 2;
+      }
     }
 
-    rectsToRemove.forEach((i) => {
-      this.rects[i].el.position.x = this.width + this.rects[i].size / 2;
-    });
     requestAnimationFrame(this.animate.bind(this), this.renderer.domElement);
     this.renderer.render(this.scene, this.camera);
     this.meter.tick();
   }
 
   render() {
-    this.rects = {};
     this.scene.clear();
+
     for (let i = 0; i < this.count.value; i++) {
       const x = Math.random() * this.width;
       const y = Math.random() * this.height;
       const size = 10 + Math.random() * 40;
       const speed = (1 + Math.random()) * 1;
-      const rect = this.makeRect(x, y, size);
-      this.scene.add(rect);
-      this.rects[i] = {
-        size,
-        speed,
-        el: rect,
-      };
+      this.makeRect(x, y, size, speed);
     }
+
     this.animate();
   }
 }


### PR DESCRIPTION
Currently the THREE.js implementation for the benchmark is implemented poorly, not using PlaneGeometry, the standard way to draw squares. In addition, it doesn't even draw the same thing as the other benchmarks, as the squares are not filled in. This PR improves the implementation by matching the drawing with the others and using a more typical THREE.js. Ultimately this leads to a noticeable increase in performance, but does not change the rankings of the frameworks. Regardless this PR leads to a more convincing benchmark.

**Before:**
<img width="1024" alt="Screen Shot 2021-05-28 at 12 29 31 PM" src="https://user-images.githubusercontent.com/7624861/120014843-8c10e980-bfb0-11eb-9eae-614d33e29a08.png">
<img width="1025" alt="Screen Shot 2021-05-28 at 12 29 38 PM" src="https://user-images.githubusercontent.com/7624861/120014850-8ddaad00-bfb0-11eb-9c0a-f50926ad8eda.png">
<img width="1052" alt="Screen Shot 2021-05-28 at 12 29 51 PM" src="https://user-images.githubusercontent.com/7624861/120014854-8f0bda00-bfb0-11eb-8f5d-3135cfa7ec98.png">


**After:**
<img width="840" alt="Screen Shot 2021-05-28 at 12 11 18 PM" src="https://user-images.githubusercontent.com/7624861/120014900-99c66f00-bfb0-11eb-9220-05e4aae82006.png">
<img width="1027" alt="Screen Shot 2021-05-28 at 1 27 08 PM" src="https://user-images.githubusercontent.com/7624861/120020991-7a334480-bfb8-11eb-96b1-41eac8171b3f.png">
<img width="837" alt="Screen Shot 2021-05-28 at 12 11 32 PM" src="https://user-images.githubusercontent.com/7624861/120014903-9a5f0580-bfb0-11eb-8500-3127d0fcffbe.png">

