### PR TITLE
Fix bug where fps meter would be ticked on dead animation frame requests

### DIFF
--- a/src/scripts/three.js
+++ b/src/scripts/three.js
@@ -48,7 +48,7 @@ class ThreeEngine extends Engine {
       }
     }
 
-    requestAnimationFrame(this.animate.bind(this), this.renderer.domElement);
+    this.lastFrame = requestAnimationFrame(this.animate.bind(this), this.renderer.domElement);
     this.renderer.render(this.scene, this.camera);
     this.meter.tick();
   }
@@ -62,6 +62,11 @@ class ThreeEngine extends Engine {
       const size = 10 + Math.random() * 40;
       const speed = (1 + Math.random()) * 1;
       this.makeRect(x, y, size, speed);
+    }
+
+    if(this.lastFrame) {
+      // Avoid overlapping animation requests to keep FPS meter working
+      cancelAnimationFrame(this.lastFrame);  
     }
 
     this.animate();


### PR DESCRIPTION
This fixes a bug in the THREE.js implementation where the animation frame requests would not get killed when changing the number of squares, causing performance to slow but also invalidate the fps meter.

<img width="253" alt="Screen Shot 2021-06-06 at 5 56 48 PM" src="https://user-images.githubusercontent.com/7624861/120941415-ab1a2480-c6f0-11eb-9a32-44e00b484797.png">
