### PR TITLE
Fix: optimize three.js

### DIFF
--- a/src/scripts/three.js
+++ b/src/scripts/three.js
@@ -11,8 +11,11 @@ class ThreeEngine extends Engine {
       1000
     );
     this.camera.position.set(this.width / 2, this.height / 2, 500);
-    this.renderer = new THREE.WebGLRenderer({ antialias: true, depth: false });
-    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      depth: false,
+      precision: "lowp",
+    })
     this.renderer.setSize(this.width, this.height);
     this.renderer.sortObjects = false; // Allows squares to be drawn on top of each other
     this.content.appendChild(this.renderer.domElement);


### PR DESCRIPTION
Hi!

This is a very small update to optimize a threejs renderer (now it's >3x faster on my computer, from 9 to 33 fps on 5K rectangles) and to make the settings of the renderer same as for pixi.js (dpi = 1).

And thanks for the benchmark, it's really great!