### PR TITLE
Update scrawl-canvas library to v8.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pencil.js": "^1.9.0",
     "pixi.js": "6.1.3",
     "pts": "^0.10.6",
-    "scrawl-canvas": "^8.6.2",
+    "scrawl-canvas": "^8.8.1",
     "three": "0.132.2",
     "two.js": "0.7.8",
     "zrender": "^5.2.1"

--- a/src/scripts/scrawl-canvas.js
+++ b/src/scripts/scrawl-canvas.js
@@ -1,5 +1,5 @@
 import Engine from "./engine";
-import scrawl from "scrawl-canvas";
+import * as scrawl from "scrawl-canvas";
 
 class SCEngine extends Engine {
   constructor() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5888,10 +5888,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scrawl-canvas@^8.6.2:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/scrawl-canvas/-/scrawl-canvas-8.6.2.tgz#1a00c3aeed705dbf02a37fe919c9b54d08daeeef"
-  integrity sha512-aib5UqqcwIkKXMu+Fuk9y+h0JfDA/4i0eWIgsN3inf7JZViKfOpM/FbHXrEVkO1IP1RskRRG951Bt5JfYn4w4w==
+scrawl-canvas@^8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/scrawl-canvas/-/scrawl-canvas-8.8.1.tgz#7fcf0793c3557e7699b9fd254dea9636bca00b7d"
+  integrity sha512-Qd50VH6f0VI6AJXiHKSCYRb6exQ/1JLi8j6opFfXlbpqWkH9ppc4Ym+JBIT20/lv9pSkmJ/0FsHx/HbsPVzF6Q==
 
 semver@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Scrawl-canvas has been evolving a lot since it was last updated in the comparisons test. This PR brings the library used here in line with those latest developments.