### PR TITLE
Add more options for more rects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://benchmarks.slaylines.io/
 
 ## Description
 
-- Up to 8000 different rectangles moving on a canvas with various speed
+- Up to 32000 different rectangles moving on a canvas with various speed
 - Different choice of libraries used to render the scene :
 
 |                                                            | module kb                                                  |

--- a/src/pages/partials/count-selector.pug
+++ b/src/pages/partials/count-selector.pug
@@ -6,3 +6,5 @@ mixin count-selector()
     a(href="") 2000
     a(href="") 5000
     a(href="") 8000
+    a(href="") 16000
+    a(href="") 32000


### PR DESCRIPTION
With `pixi.js` on an M1 Max, 8000 rects is too few to dip below the vsync limit.

Even with 32000, I see ~40fps and this is no longer the fastest chip on the block, so this adds up to 64000 for a bit of headroom.

I realize that 8000 may have been chosen as a safe value to keep users from murdering their browsers, especially with slower engines. Maybe we could throw a `⚠` next to the labels > 8000 or something?