### PR TITLE
Update Scrawl-canvas to latest version 8.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pencil.js": "^1.9.0",
     "pixi.js": "6.1.3",
     "pts": "^0.10.6",
-    "scrawl-canvas": "^8.10.0",
+    "scrawl-canvas": "^8.10.1",
     "three": "0.132.2",
     "two.js": "0.7.8",
     "zrender": "^5.2.1"

--- a/src/scripts/scrawl-canvas.js
+++ b/src/scripts/scrawl-canvas.js
@@ -83,8 +83,8 @@ class SCEngine extends Engine {
         box = boxes[i];
         [x, y, dX, w] = box;
 
-        ctx.fillRect(x, y, w, w);
-        ctx.strokeRect(x, y, w, w);
+        ctx.fillRect(~~x, ~~y, w, w);
+        ctx.strokeRect(~~x, ~~y, w, w);
 
         x += dX;
         if (x < -w) x += width + w * 2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,9 +2189,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001261:
-  version "1.0.30001263"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001263.tgz#7ce7a6fb482a137585cbc908aaf38e90c53a16a4"
-  integrity sha512-doiV5dft6yzWO1WwU19kt8Qz8R0/8DgEziz6/9n2FxUasteZNwNNYSmJO3GLBH8lCVE73AB1RPDPAeYbcO5Cvw==
+  version "1.0.30001468"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001468.tgz"
+  integrity sha512-zgAo8D5kbOyUcRAgSmgyuvBkjrGk5CGYG5TYgFdpQv+ywcyEpo1LOWoG8YmoflGnh+V+UsNuKYedsoYs0hzV5A==
 
 canvas@^2.6.1:
   version "2.8.0"
@@ -5888,10 +5888,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scrawl-canvas@^8.10.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/scrawl-canvas/-/scrawl-canvas-8.10.0.tgz#5d7c15fafdfe64316fd0a171526d41068cf2de00"
-  integrity sha512-WYa3Tp0nj/zgRNa9YEEerMnLm0WQU36bGQUPnr3Sf/e1XdEUZGkxkQumNPPLvNtLBc4SJEE4ptN7OGUVKNNMHg==
+scrawl-canvas@^8.10.1:
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/scrawl-canvas/-/scrawl-canvas-8.10.1.tgz#694cf253705a935c92bc1e7d55dbbc33d6aef046"
+  integrity sha512-+Z3mwGscu/1yo7PQcHJ94w4hhd3poR9ne0zX5uUb2hbWV3LVXwWQpWXyeqcbiu7qUeUT318cMm6SZjo9JXeWWw==
 
 semver@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Updating to latest version of SC.

Interesting to compare libraries across browsers - it might just be my local machine (MacBook Pro circa 2019) but the differences on latest versions of browsers (on 8k boxes) seem surprising:

| Library | Chrome | Firefox | Safari |
| --- | --- | --- | --- |
| Pixi | **60** | 43 | 24 |
| Scrawl-canvas | 51 | **60** | 32 |
| P5 | 15 | 4 | **34** |
| Mesh | 47 | 30 | 18 |
| ZRender | 13 | 4 | 22 |
| Two | 23 | 21 | 16 |
| Konva | 23 | 7 | 16 |
| CanvasKit | 17 | 19 | 19 |
| Paper | 16 | 6 | 14 |
| Easel | 11 | 4 | 22 |
| Pencil | 12 | 3 | 19 |
| Pts | 12 | 4 | 11 |
| Fabric | 9 | 4 | 7 |
| SVG | 10 | 7 | 8 |
| Three | 8 | 6 | 4 |
| DOM | 12 | 1 | 9 |
