### PR TITLE
Update DOM demo; add Raw JS demo; bump SC to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,27 @@ https://benchmarks.slaylines.io/
 | [SVG.js](https://github.com/svgdotjs/svg.js)               | ![](https://badgen.net/bundlephobia/min/@svgdotjs/svg.js)  |
 
 
-Thanks to [KaliedaRik](https://github.com/KaliedaRik) for the comparison of the performance in different browsers (MacBook Pro 2019, 8k boxes):
+Thanks to [KaliedaRik](https://github.com/KaliedaRik) for the (highly unscientific) comparison of the performance in different browsers (MacBook Pro 2019, 8k boxes):
 
 | Library | Chrome | Firefox | Safari |
 | --- | --- | --- | --- |
-| Pixi | 60 | 43 | 24 |
-| Scrawl-canvas | 51 | 60 | 32 |
-| P5 | 15 | 4 | 34 |
-| Mesh | 47 | 30 | 18 |
-| ZRender | 13 | 4 | 22 |
-| Two | 23 | 21 | 16 |
-| Konva | 23 | 7 | 16 |
-| CanvasKit | 17 | 19 | 19 |
-| Paper | 16 | 6 | 14 |
-| Easel | 11 | 4 | 22 |
+| Pixi | 60 | 48 | 24 |
+| Scrawl-canvas | 56 | 60 | 40 |
+| P5 | 15 | 4 | 44 |
+| Mesh | 47 | 34 | 18 |
+| ZRender | 13 | 4 | 28 |
+| Two | 23 | 25 | 16 |
+| Konva | 23 | 7 | 19 |
+| CanvasKit | 17 | 19 | 22 |
+| Paper | 16 | 6 | 16 |
+| Easel | 11 | 4 | 28 |
 | Pencil | 12 | 3 | 19 |
-| Pts | 12 | 4 | 11 |
-| Fabric | 9 | 4 | 7 |
-| SVG | 10 | 7 | 8 |
-| Three | 8 | 6 | 4 |
-| DOM | 12 | 1 | 9 |
+| Pts | 12 | 4 | 13 |
+| Fabric | 9 | 4 | 9 |
+| SVG | 10 | 7 | 10 |
+| Three | 8 | 7 | 4 |
+| DOM | 17 | 1 | 11 |
+| Raw JS | 19 | 19 | 39 |
 
 
 ## Quick Start

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pencil.js": "^1.9.0",
     "pixi.js": "6.1.3",
     "pts": "^0.10.6",
-    "scrawl-canvas": "^8.10.1",
+    "scrawl-canvas": "^8.10.3",
     "three": "0.132.2",
     "two.js": "0.7.8",
     "zrender": "^5.2.1"

--- a/src/pages/partials/header.pug
+++ b/src/pages/partials/header.pug
@@ -14,8 +14,9 @@ mixin header()
       a(href="./pts.pug") Pts
       a(href="./fabric.pug") Fabric.js
       a(href="./svgjs.pug") SVG.js
-      a(href="./scrawl-canvas.pug") Scrawl-canvas.js
+      a(href="./scrawl-canvas.pug") Scrawl-canvas
       a(href="./threejs.pug") Three JS
       a(href="./dom.pug") DOM
+      a(href="./vanilla.pug") Raw JS
 
     a.github(href="https://github.com/slaylines/canvas-engines-comparison" target="_blank") See on GitHub

--- a/src/pages/vanilla.pug
+++ b/src/pages/vanilla.pug
@@ -1,0 +1,7 @@
+extends /layouts/main.pug
+
+block title
+  title Raw Javascript — Canvas Engines Comparison
+
+block scripts
+  script(src="../scripts/vanilla.js")

--- a/src/scripts/dom.js
+++ b/src/scripts/dom.js
@@ -1,25 +1,23 @@
 import Engine from "./engine";
-import { fabric } from "fabric";
 
-class FabricEngine extends Engine {
+class DomEngine extends Engine {
   constructor() {
     super();
     this.canvas = document.createElement("div");
     this.canvas.className = "canvas";
     this.canvas.style.width = this.width;
     this.canvas.style.height = this.height;
+    this.canvas.style.position = "relative";
     this.content.appendChild(this.canvas);
   }
 
-  init() {}
-
   animate() {
     const rects = this.rects;
-    for (let i = 0; i < this.count.value; i++) {
+    for (let i = 0, iz =  this.count.value; i < iz; i++) {
       const r = rects[i];
       r.x -= r.speed;
-      r.el.style.left = r.x;
-      if (r.x + r.size < 0) {
+      r.el.style.transform = `translate(${r.x}px, ${r.y}px)`;
+      if (r.x + (r.size * 2) < 0) {
         r.x = this.width + r.size;
       }
     }
@@ -34,7 +32,7 @@ class FabricEngine extends Engine {
     this.cancelAnimationFrame(this.request);
 
     // rectangle creation
-    const rects = new Array(this.count);
+    const rects = [];
     for (let i = 0; i < this.count.value; i++) {
       const x = Math.random() * this.width;
       const y = Math.random() * this.height;
@@ -43,10 +41,10 @@ class FabricEngine extends Engine {
 
       let rect = document.createElement("div");
       rect.className = "rectangle";
-      rect.style.left = x + "px";
-      rect.style.top = y + "px";
       rect.style.width = size + "px";
       rect.style.height = size + "px";
+      rect.style.position = "absolute";
+      rect.style.transform = `translate(${x}px, ${y}px)`;
       this.canvas.appendChild(rect);
       rects[i] = { x, y, size: size / 2, speed, el: rect };
     }
@@ -57,7 +55,6 @@ class FabricEngine extends Engine {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  const engine = new FabricEngine();
-  engine.init();
+  const engine = new DomEngine();
   engine.render();
 });

--- a/src/scripts/scrawl-canvas.js
+++ b/src/scripts/scrawl-canvas.js
@@ -12,21 +12,29 @@ class SCEngine extends Engine {
     const namespace = 'vanilla';
     const name = n => `${namespace}-${n}`;
 
-    // Handle pixelRatio edge case where user drags browser between screens of different pixel densities
+    // Variables
     let pixRatio = scrawl.getPixelRatio();
 
-    scrawl.setPixelRatioChangeAction(() => {
-      pixRatio = scrawl.getPixelRatio();
-      buildCanvas();
-      buildBoxes(boxes, count.value);
-    });
+    const { meter, count, width, height } = this;
 
-    // Render variables
-    let { meter, count, width, height } = this;
+    let pixWidth = width / pixRatio;
 
     let canvas, ctx;
 
+    const rnd = Math.random;
+
     const boxes = [];
+
+    // Handle pixelRatio edge case where user drags browser between screens of different pixel densities
+    scrawl.setPixelRatioChangeAction(() => {
+
+      pixRatio = scrawl.getPixelRatio();
+      pixWidth = width / pixRatio;
+
+      buildCanvas();
+      
+      buildBoxes(boxes, count.value);
+    });
 
     // Create the canvas element; import it into the SC library; set up its context engine; create the animation loop
     const buildCanvas = () => {
@@ -34,8 +42,8 @@ class SCEngine extends Engine {
       if (scrawl.library.canvas[namespace]) scrawl.library.purge(namespace);
 
       this.canvas = document.createElement('canvas');
-      this.canvas.width = this.width;
-      this.canvas.height = this.height;
+      this.canvas.width = width;
+      this.canvas.height = height;
       this.canvas.id = namespace;
       this.content.appendChild(this.canvas);
 
@@ -43,7 +51,7 @@ class SCEngine extends Engine {
       ctx = canvas.base.engine;
       ctx.fillStyle = "white";
       ctx.strokeStyle = "black";
-      ctx.lineWidth = 1 / pixRatio;
+      ctx.lineWidth = 1;
 
       scrawl.makeAnimation({
         name: name('demo'),
@@ -60,15 +68,16 @@ class SCEngine extends Engine {
 
     // Create the array of box data used in the animation
     function buildBoxes(boxes, boxesRequired) {
+
       let size, x, y, dx;
 
       boxes.length = 0;
 
       for (let i = 0; i < boxesRequired; i++) {
-        size = Math.floor(10 + Math.random() * 40) / pixRatio;
-        x = Math.random() * width;
-        y = (Math.random() * height) - (size / 2);
-        dx = -1 - Math.random();
+        size = ~~((10 + rnd() * 40) / pixRatio);
+        x = rnd() * pixWidth;
+        y = ~~((rnd() * height) - (size / 2)) / pixRatio;
+        dx = (-1 - rnd()) / pixRatio;
 
         boxes.push([x, y, dx, size]);
       }
@@ -77,17 +86,20 @@ class SCEngine extends Engine {
     // Draw the boxes onto the canvas; update each box's position
     const drawBoxes = () => {
 
-      let box, x, y, dX, w;
+      let box, x, y, dX, w, bx;
 
       for (let i = 0, iz = boxes.length; i < iz; i++) {
+
         box = boxes[i];
         [x, y, dX, w] = box;
 
-        ctx.fillRect(~~x, ~~y, w, w);
-        ctx.strokeRect(~~x, ~~y, w, w);
+        bx = ~~x;
+
+        ctx.fillRect(bx, y, w, w);
+        ctx.strokeRect(bx, y, w, w);
 
         x += dX;
-        if (x < -w) x += width + w * 2;
+        if (x < -w) x += pixWidth + w * 2;
         box[0] = x;
       }
     };

--- a/src/scripts/vanilla.js
+++ b/src/scripts/vanilla.js
@@ -1,0 +1,76 @@
+import Engine from "./engine";
+
+class VanillaEngine extends Engine {
+  constructor() {
+    super();
+
+    const {width, height} = this;
+
+    const canvas = document.createElement("canvas");
+    canvas.className = "canvas";
+    canvas.width = width;
+    canvas.height = height;
+
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgb(255 255 255 / 1)';
+    ctx.strokeStyle = 'rgb(0 0 0 / 1)';
+    this.ctx = ctx;
+
+    this.content.appendChild(canvas);
+  }
+
+  animate() {
+    const {rects, width, height, ctx} = this;
+
+    ctx.clearRect(0, 0, width, height);
+
+    let rect, x, y, size, speed, rx;
+
+    for (let i = 0, iz = rects.length; i < iz; i++) {
+      
+      rect = rects[i];
+      [x, y, size, speed] = rect;
+
+      rx = ~~(x);
+
+      ctx.fillRect(rx, y, size, size);
+      ctx.strokeRect(rx, y, size, size);
+
+      x += speed;
+      if (x < -size) {
+        x += width + size;
+      }
+      rect[0] = x;
+    }
+    this.meter.tick();
+
+    this.request = requestAnimationFrame(() => this.animate());
+  }
+
+  render() {
+    this.cancelAnimationFrame(this.request);
+
+    const dpr = window.devicePixelRatio;
+    const rnd = Math.random;
+    const {count, width, height} = this;
+
+    // rectangle creation
+    const rects = [];
+    for (let i = 0, iz = count.value; i < iz; i++) {
+      const size = ~~(10 + rnd() * 40);
+      const x = rnd() * width;
+      const y = ~~(rnd() * height);
+      const speed = -1 - rnd();
+
+      rects.push([x, y, size, speed]);
+    }
+    this.rects = Object.freeze(rects);
+
+    this.request = requestAnimationFrame(() => this.animate());
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const engine = new VanillaEngine();
+  engine.render();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5888,10 +5888,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scrawl-canvas@^8.10.1:
-  version "8.10.1"
-  resolved "https://registry.yarnpkg.com/scrawl-canvas/-/scrawl-canvas-8.10.1.tgz#694cf253705a935c92bc1e7d55dbbc33d6aef046"
-  integrity sha512-+Z3mwGscu/1yo7PQcHJ94w4hhd3poR9ne0zX5uUb2hbWV3LVXwWQpWXyeqcbiu7qUeUT318cMm6SZjo9JXeWWw==
+scrawl-canvas@^8.10.3:
+  version "8.10.3"
+  resolved "https://registry.yarnpkg.com/scrawl-canvas/-/scrawl-canvas-8.10.3.tgz#2d42f70fd2dad5f578b14a3971093f69525a5eea"
+  integrity sha512-MykgPVV/sFkbzW/FMsDml/u0k3H36RVnrn7PAJAwUfb5TjBGNmbd4yC0s+N+F0aii4D9eY4XdMtc0Cc3P3IgTQ==
 
 semver@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
#### Update DOM demo
Previously, the demo was positioning the `div` elements using `style.top` and `style.left` which have significant performance issues for animation. This PR updates positioning to use `style.transform = translate()`

#### Add a 'raw' (vanilla) Javascript demo
... Mainly because I was interested to see how it would perform compared to the JS canvas libraries

#### Bump Scrawl-canvas to latest version
SC v8.10.3 completes the code efficiency work I've been doing over the past few weeks
