### PR TITLE
Fixes array reinitialization

### DIFF
--- a/src/scripts/pixi.js
+++ b/src/scripts/pixi.js
@@ -39,7 +39,7 @@ class PixiEngine extends Engine {
   render() {
     this.app.ticker.remove(this.onTick, this);
     this.app.stage.removeChildren();
-    this.rects = {};
+    this.rects = [];
     for (let i = 0; i < this.count.value; i++) {
       const x = Math.random() * this.width;
       const y = Math.random() * this.height;


### PR DESCRIPTION
`this.rects` is an array, as set up in the `constructor` in line 10. I think this is a mistake. Instead of something like this: `rects = [{object}, {object}, ...]` this is creating something like this: `{0: {object}, 1: {object}, ...}`. I don't know if this can affect performance in any noticiable way but I think it may be worth changing.

BTW Thanks for the repo!